### PR TITLE
Added Github Workflow for Jest Coverage Check and Publishing to npm

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -1,0 +1,18 @@
+name: Jest Coverage Comment
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: |
+          npx jest --coverage --coverageReporters json-summary --passWithNoTests
+
+      - name: Jest Coverage Comment
+        uses: MishaKav/jest-coverage-comment@main

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,55 @@
+name: Readme Badge and Publish
+on:
+  push:
+
+jobs:
+  update-coverage-in-readme:
+    name: Update Coverage in README
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install 
+        run: |
+          npm install
+
+      - name: Run tests
+        run: |
+          npx jest --coverage --coverageReporters json-summary --passWithNoTests
+
+      - name: Jest Coverage Comment
+        id: coverageComment
+        uses: MishaKav/jest-coverage-comment@main
+        with:
+          hide-comment: true
+          coverage-summary-path: ./coverage/coverage-summary.json
+
+      - name: Check the output coverage
+        run: |
+          echo "Coverage Percentage - ${{ steps.coverageComment.outputs.coverage }}"
+          echo "Coverage Color - ${{ steps.coverageComment.outputs.color }}"
+          echo "Summary HTML - ${{ steps.coverageComment.outputs.summaryHtml }}"
+
+      - name: Create the badge
+        if: github.ref == 'refs/heads/main'
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.JEST_COVERAGE_COMMENT }}
+          gistID: 5e90d640f8c212ab7bbac38f72323f80
+          filename: jest-coverage-comment__main.json
+          label: Coverage
+          message: ${{ steps.coverageComment.outputs.coverage }}%
+          color: ${{ steps.coverageComment.outputs.color }}
+          namedLogo: javascript 
+
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.18"
+      - run: npm install
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "author": "",
-  "private": true,
+  "private": false,
   "license": "MIT",
   "scripts": {
     "seed:create": "hygen seeds create",


### PR DESCRIPTION
Fixes #5 

For the jest coverage, I couldn't find anything that compares the difference between current coverage and PR coverage. So, in the proposed flow for now, after every commit the current coverage will be updated in the readme badge, and at every PR, a detailed coverage report will be generated. The readme badge can be used as a reference to compare the two coverages and spot any discrepancies. 